### PR TITLE
v3

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ if [ "x${INPUT_POLICY_TYPE}" != "x" ]; then
     args="${args} -t ${INPUT_POLICY_TYPE}"
 fi
 if [ "x${INPUT_SKIP_RULES}" != "x" ]; then
-    args="${args} --skip-rules=\'${INPUT_SKIP_RULES}\'"
+    args="${args} --skip-rules='${INPUT_SKIP_RULES}'"
 fi
 if [ "x${INPUT_CONFIG_PATH}" != "x" ]; then
     args="${args} -c ${INPUT_CONFIG_PATH}"
@@ -96,9 +96,12 @@ if [ "x${REPO_URL}" != "x" ]; then
     args="${args} --repo-ref ${REF_NAME}"
 fi
 
+if [ -f ".terrascanrc.toml" ]; then
+    args="${args} -c .terrascanrc.toml"
+fi
+
 ## Generate action outputs
 echo "{err}=${res}" >> $GITHUB_OUTPUT
-#command="terrascan scan ${args}"
 command="terrascan scan ${args}"
 result=$( $command )
 result="${result//'%'/'%25'}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,7 +71,7 @@ if [ "x${INPUT_POLICY_TYPE}" != "x" ]; then
     args="${args} -t ${INPUT_POLICY_TYPE}"
 fi
 if [ "x${INPUT_SKIP_RULES}" != "x" ]; then
-    args="${args} --skip-rules='${INPUT_SKIP_RULES}'"
+    args="${args} --skip-rules=\'${INPUT_SKIP_RULES}\'"
 fi
 if [ "x${INPUT_CONFIG_PATH}" != "x" ]; then
     args="${args} -c ${INPUT_CONFIG_PATH}"


### PR DESCRIPTION
This pull request includes a small change to the `entrypoint.sh` file. The change adds support for using a `.terrascanrc.toml` configuration file if it exists.

* [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R99-L101): Added a conditional check to include the `.terrascanrc.toml` configuration file in the `terrascan` command arguments if the file is present.